### PR TITLE
#162995162- voting routes

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,5 @@
+{
+    "presets": [
+        "@babel/preset-env"
+    ]
+}

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+    "extends": "airbnb-base",
+    "rules": {
+        "linebreak-style": 0
+    }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+.nyc_output
+coverage
+.coveralls.yml
+.env

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: node_js
+node_js:
+ - "stable"
+env:
+  global:
+    - CC_TEST_REPORTER_ID=8962bed5ff369510949100055043152bad5a4be2e23d296376bd2efc34225791
+before_script:
+   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+   - chmod +x ./cc-test-reporter
+   - ./cc-test-reporter before-build  
+script:
+  - npm test
+after_script:
+  - npm run coverage
+  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # Questioner
+[![Build Status](https://travis-ci.org/openwell/questioner.svg?branch=develop)](https://travis-ci.org/openwell/questioner)
 [![Coverage Status](https://coveralls.io/repos/github/openwell/questioner/badge.svg?branch=develop)](https://coveralls.io/github/openwell/questioner?branch=develop)
-
 [![Maintainability](https://api.codeclimate.com/v1/badges/a3a966589be730bc865e/maintainability)](https://codeclimate.com/github/openwell/questioner/maintainability)
-
 [![Test Coverage](https://api.codeclimate.com/v1/badges/a3a966589be730bc865e/test_coverage)](https://codeclimate.com/github/openwell/questioner/test_coverage)
 
 Crowd-source questions for a meetup. Questioner helps the meetup organizer prioritize

--- a/src/controller/meetUpController.js
+++ b/src/controller/meetUpController.js
@@ -54,5 +54,25 @@ class Controller {
       data: [result],
     });
   }
+  //  upVote (increase votes by 1) a specific question.
+  static upVote(req, res) {
+    const upVoteQuestionId = req.params.questionId;
+    const result = model.vote(upVoteQuestionId, '+');
+    return res.status(200).json({
+      status: 200,
+      data: [result],
+    });
+  }
+
+  // downVote (decrease votes by 1) a specific question.
+  static downVote(req, res) {
+    const downVoteQuestionId = req.params.questionId;
+    const result = model.vote(downVoteQuestionId, '-');
+    return res.status(200).json({
+      status: 200,
+      data: [result],
+    });
+  }
+
 }
 export default Controller;

--- a/src/routes/meetUpRoute.js
+++ b/src/routes/meetUpRoute.js
@@ -14,6 +14,8 @@ router.get('/meetups', validate.checkMeetUpEmpty, controller.allMeetUps);
 router.get('/meetups/1/:meetupId', validate.checkMeetUpId, controller.findMeetUpsById);
 router.get('/meetups/upcoming', validate.checkMeetUpEmpty, controller.upComingMeetUps);
 router.post('/questions', validate.question, controller.questionEntry);
+router.patch('/questions/:questionId/upvote', validate.checkQuestionId, controller.upVote);
+router.patch('/questions/:questionId/downvote', validate.checkQuestionId, controller.downVote);
 
 export default router;
 


### PR DESCRIPTION
#### What does this PR do?
- This PR integrates an Api route to vote on a question on the app
#### Description of Task to be completed?
- When a PATCH request is sent to **localhost:3000/api/v1/questions/:questionId/upvote**, a +1 vote is added to votes
- When a PATCH request is sent to **localhost:3000/api/v1/questions/:questionId/downvote**, a -1 vote is substracted fron votes
- An user's request can only be completed when all the required data are sent
- A successful request should return a status of 200
#### How should this be manually tested?
- Pull this branch [ft-user-able-vote-or-against-162995162](https://github.com/openwell/questioner/tree/ft-user-able-vote-or-against-162995162) off this repository
- On your command line, run **npm install** to install all dependencies for this app
- On your command line, run **npm start** to start the app
- App would run on port 3000
- Access the endpoint with a POST request on **localhost:3000/api/v1//questions/:questionId/upvote**
- Access the endpoint with a POST request on **localhost:3000/api/v1//questions/:questionId/downvote**
#### Any background context you want to provide?
- This app is a node app and would require nodejs and npm installation on your local machine
#### What are the relevant pivotal tracker stories?
[162995162](https://www.pivotaltracker.com/story/show/162995162)
#### Screenshots (if appropriate)
None
#### Questions:
None