### PR TITLE
#163279971- Route get all comments

### DIFF
--- a/src/controller/meetUpController.js
+++ b/src/controller/meetUpController.js
@@ -187,5 +187,22 @@ class Controller {
       return errorHandler(400, res, err);
     }
   }
+  static async allComment(req, res) {
+    try {
+      const { rows } = await db.query(queries.selectAll('comments'));
+      const result = rows.map(({
+        question_id, comment,
+      }) => ({
+        question_id, comment,
+      }));
+      return res.status(200).json({
+        status: 200,
+        data: result,
+      });
+    } catch (err) {
+      return errorHandler(400, res, err);
+    }
+  }
+
 }
 export default Controller;

--- a/src/controller/queries.js
+++ b/src/controller/queries.js
@@ -23,7 +23,7 @@ const Queries = {
       text: `INSERT INTO
       questions(createdon, createdby, meetup_id, title, body, votes)
       VALUES($1, $2, $3, $4, $5, $6)
-      returning createdby, meetup_id, title, body,`,
+      returning createdby, meetup_id, title, body`,
       values: [createdOn, createdBy, meetupId, title, body, votes],
     };
   },

--- a/src/routes/commentRoutes.js
+++ b/src/routes/commentRoutes.js
@@ -6,6 +6,9 @@ import validateExit from '../helpers/validateExist';
 
 const router = express.Router();
 
+router.get('/comments',
+  controller.allComment);
+
 router.post('/comments',
   validate.comment,
   auth.verifyToken,


### PR DESCRIPTION
#### What does this PR do?
- This PR integrates Api routes to view all comments
#### Description of Task to be completed?
- When a GET request is sent to **localhost:3000/api/v1/comments**, a list of all comments should be populated
- A successful request should return a status of 200
#### How should this be manually tested?
- Pull this branch [ft-user-able-get-all-comments-163279971](https://github.com/openwell/questioner/tree/ft-user-able-get-all-comments-163279971) off this repository
- On your command line, run **npm install** to install all dependencies for this app
- On your command line, run **npm start** && **npm run preTest** to start the app
- App would run on port 3000
- Access the endpoint with a GET request on **localhost:3000/api/v1/comments** 
#### Any background context you want to provide?
- This app is a node app and would require nodejs and npm installation on your local machine
#### What are the relevant pivotal tracker stories?
[163279971](https://www.pivotaltracker.com/story/show/163279971)
#### Screenshots (if appropriate)
None
#### Questions:
None