### PR TITLE
#163653406 admin can delete a meetup

### DIFF
--- a/UI/resources/js/main.js
+++ b/UI/resources/js/main.js
@@ -396,7 +396,6 @@ function signin() {
 /*======================================================
                     //Auto load of all meetups
 ======================================================*/
-
 function loadMeetupsPage() {
   document.getElementById("cs-loader").removeAttribute("hidden", "false");
   const url = `${baseUrl}/meetups`;
@@ -478,10 +477,6 @@ function adminSignin() {
   }
   postAdminSignin(request);
 }
-
-/*======================================================
-                    // admin table get all meetup
-======================================================*/
 function loadAllMeetupAdmin() {
   if (localStorage.getItem("adminToken") === null) {
     return (window.location.href = "login.html");
@@ -559,4 +554,35 @@ function newMeetup() {
     }
   });
   postMeetup(request);
+}
+
+
+/*======================================================
+                    // delete meetup
+======================================================*/
+function deleteMeetup(id) {
+  if (localStorage.getItem("adminToken") === null) {
+    return (window.location.href = "login.html");
+  }
+  async function delMeetup(payLoad) {
+    try {
+      let response = await fetch(payLoad);
+      let data = await response.json();
+      location.reload();
+      return response.status;
+    } catch (err) {
+      throw err;
+    }
+  }
+
+  const url = `${baseUrl}/meetups/${id}`;
+  let request = new Request(url, {
+    method: "DELETE",
+    headers: {
+      Accept: "application/json, text/plain, */*",
+      "Content-Type": "application/json",
+      tokens: localStorage.getItem("adminToken")
+    }
+  });
+  delMeetup(request);
 }


### PR DESCRIPTION
#### What does this PR do?
- This PR enables the admin to delete a meetup
#### Description of Task to be completed?
- When an admin navigates to `admin/login.html` and fills the login form with the right details
- A successful request should return a status of 200 and redirect to the admin dashboard
#### How should this be manually tested?
- Pull this branch [ft-admin-able-delete-meetup-163653406](https://github.com/openwell/questioner/tree/ft-admin-able-delete-meetup-163653406) off this repository
- Navigate to `admin/login.html` to login
- Login with the right details and a redirect will take you to the dashboard
- The admin can now view all meetup and click the delete button by the side to delete a meetup
#### Any background context you want to provide?
- None
#### What are the relevant pivotal tracker stories?
[#163653406](https://www.pivotaltracker.com/story/show/163653406)
#### Screenshots (if appropriate)
None
#### Questions:
None